### PR TITLE
(Fix) Application load balancer name

### DIFF
--- a/load-balancer.tf
+++ b/load-balancer.tf
@@ -1,6 +1,8 @@
 resource "aws_alb" "main" {
   count = "${var.enable_lb ? 1 : 0}" ## Load Balancer
 
+  name = "${var.environment}-${var.service_name}"
+
   internal        = "${var.lb_internal}"
   subnets         = ["${var.lb_subnetids}"]
   security_groups = ["${aws_security_group.alb_sg.id}"]
@@ -29,6 +31,8 @@ resource "aws_alb_listener" "main" {
 
 resource "aws_alb_target_group" "main" {
   count = "${var.enable_lb ? 1 : 0}"
+
+  name = "${var.environment}-${var.service_name}"
 
   port        = "${lookup(var.lb_target_group, "host_port", 80)}"
   protocol    = "${upper(lookup(var.lb_target_group, "protocol", "HTTP"))}"


### PR DESCRIPTION
* Currently only the 'Name' tag is set, which doesn't set the Name
attribute for the resources. This results in randomly generated resource
names