### PR TITLE
enables to specify the ip whitelisting on public ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ module "blog" {
 | task_role_arn | The AWS IAM role that will be provided to the task to perform AWS actions. | string | `` | no |
 | vpc_cidr | CIDR for the VPC. | string | - | yes |
 | vpc_id | ID of the VPC. | string | - | yes |
+| public_alb_whitelist | Whitelists IP to be able to access ALB | list | ["0.0.0.0/0","::/0"] | no |
 
 ## Outputs
 

--- a/load-balancer.tf
+++ b/load-balancer.tf
@@ -60,7 +60,7 @@ resource "aws_security_group" "alb_sg" {
     protocol    = "tcp"
     from_port   = "${lookup(var.lb_listener, "port", 80)}"
     to_port     = "${lookup(var.lb_listener, "port", 80)}"
-    cidr_blocks = ["${var.lb_internal ? "${var.vpc_cidr}" : "0.0.0.0/0"}"]
+    cidr_blocks = ["${split(",",var.lb_internal ? var.vpc_cidr : join(",",var.public_alb_whitelist))}"]
   }
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,9 @@ variable "enable_lb" {
 variable "ecs_service_role" {
   default = ""
 }
+
+variable "public_alb_whitelist" {
+  type = "list"
+  description = "Enables to limit the ips that can access the  ALB over public network"
+  default = ["0.0.0.0/0","::/0"]
+}


### PR DESCRIPTION
added variable public_alb_whitelist , which allows you to specify the arrray of whitelisted IP , could be useful if one wants to restrict access to certain client/organisation etc instead of making application available to everyone
