### PR TITLE
(Fix) Remove IPv6 address from `public_alb_whitelist` default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -130,5 +130,5 @@ variable "ecs_service_role" {
 variable "public_alb_whitelist" {
   type        = "list"
   description = "Enables to limit the ips that can access the  ALB over public network"
-  default     = ["0.0.0.0/0", "::/0"]
+  default     = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
* This is passed to `cidr_block` which doesn't support IPv6 addresses
* https://github.com/npalm/terraform-aws-ecs-service/issues/14