### PR TITLE
(Chore) Allow setting Load Balancer grace period

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ module "blog" {
 | lb_subnetids | List of subnets to which the load balancer needs to be attached. Mandatory when enable_alb = true. | list | `<list>` | no |
 | lb_target_group | The target group to connectect the container to the load balancer listerner. | map | `<map>` | no |
 | lb_security_group_ids | Custom Load Balancer security group ids | list | `[]` | no |
+| lb_health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647 | string | `0` | no |
 | service_desired_count | The number of instances of the task definition to place and keep running. | string | `1` | no |
 | service_launch_type | The launch type, can be EC2 or FARGATE. | string | `EC2` | no |
 | service_name | Logical name of the service. | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,8 @@ resource "aws_ecs_service" "awsvpc_alb" {
     container_port   = "${lookup(var.lb_target_group, "container_port", 8080)}"
   }
 
+  health_check_grace_period_seconds = "${var.lb_health_check_grace_period_seconds}"
+
   launch_type = "${var.service_launch_type}"
 
   network_configuration {
@@ -50,6 +52,8 @@ resource "aws_ecs_service" "bridge_alb" {
     container_name   = "${lookup(var.lb_target_group, "container_name", var.service_name)}"
     container_port   = "${lookup(var.lb_target_group, "container_port", 8080)}"
   }
+
+  health_check_grace_period_seconds = "${var.lb_health_check_grace_period_seconds}"
 
   launch_type = "${var.service_launch_type}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -144,3 +144,9 @@ variable "lb_security_group_ids" {
   type        = "list"
   default     = []
 }
+
+variable "lb_health_check_grace_period_seconds" {
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647"
+  type        = "string"
+  default     = "0"
+}


### PR DESCRIPTION
Seconds to ignore failing load balancer health checks on newly
instantiated tasks to prevent premature shutdown, up to 2147483647